### PR TITLE
Disable footer badges to allow product page badges

### DIFF
--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -117,7 +117,7 @@
             {% comment %} {% for type in shop.enabled_payment_types %} 
               <!-- <img src="{{ type | payment_type_img_url }}" alt="{{ type | replace: "_", " " | capitalize }}" /> -->
             {% endfor %} {% endcomment %}
-            <div id="hektor-trust-badge"></div>
+            <-- <div id="hektor-trust-badge"></div> -->
             <!-- END Custom Payment Badge icons -->
           </div>
         {% endif %}


### PR DESCRIPTION
- Comment out payment icons from footer to next to add to cart button on product pages